### PR TITLE
Expand shared task RLS guidance

### DIFF
--- a/supabase_schema
+++ b/supabase_schema
@@ -67,7 +67,15 @@ alter table tasks enable row level security;
 
 create policy "Users can view own tasks"
   on tasks for select
-  using (auth.uid() = user_id);
+  using (
+    auth.uid() = user_id
+    or exists (
+      select 1
+      from project_members pm
+      where pm.project_id = project_id
+        and pm.user_id = auth.uid()
+    )
+  );
 
 create policy "Users can insert own tasks"
   on tasks for insert
@@ -75,8 +83,28 @@ create policy "Users can insert own tasks"
 
 create policy "Users can update own tasks"
   on tasks for update
-  using (auth.uid() = user_id);
+  using (
+    auth.uid() = user_id
+    or exists (
+      select 1
+      from project_members pm
+      where pm.project_id = project_id
+        and pm.user_id = auth.uid()
+        and pm.role in ('owner','editor')
+    )
+  );
 
 create policy "Users can delete own tasks"
   on tasks for delete
-  using (auth.uid() = user_id);
+  using (
+    auth.uid() = user_id
+    or exists (
+      select 1
+      from project_members pm
+      where pm.project_id = project_id
+        and pm.user_id = auth.uid()
+        and pm.role = 'owner'
+    )
+  );
+
+-- Shared access is audited through project_members role assignments, keeping collaborative permissions traceable.


### PR DESCRIPTION
## Summary
- expand the task RLS examples in the PRD to include project member access for shared tasks and document shared-access auditing
- mirror the updated shared-task policies and auditing notes in the standalone Supabase schema guidance

## Testing
- not run (docs-only change)

------
https://chatgpt.com/codex/tasks/task_e_68d034764778832dae2c1bd46d7cd523